### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,17 +46,11 @@ class ItemsController < ApplicationController
                                  :shipping_day_id, :price, :image)
   end
 
-  # @item をセット
   def set_item
     @item = Item.find(params[:id])
-    return unless @item.user != current_user
-
-    redirect_to root_path
   end
-
+  
   def redirect_unless_owner
-    return unless @item.user_id != current_user.id
-
-    redirect_to root_path
+    redirect_to root_path unless @item.user_id == current_user.id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,18 +24,14 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    return if user_signed_in?
-
-    redirect_to action: :index
   end
 
   def update
-    params[:item][:image] = @item.image if params[:item][:image].blank?
 
     if @item.update(item_params)
-      redirect_to item_path(@item), notice: '商品情報を更新しました'
+      redirect_to item_path(@item)
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,13 +28,17 @@ class Item < ApplicationRecord
 
   # 商品画像
   has_one_attached :image
-  validates :image, presence: true
-
-  #has_one :order
+  validates :image, presence: true, if: :image_blank?
 
   # 売却済みかどうかを判定するメソッド
-    #def sold_out?
-      #self.order.present? # 注文が存在する場合、売却済み
-    #end
+  # def sold_out?
+  #   self.order.present? # 注文が存在する場合、売却済み
+  # end
 
+  private
+
+  # 画像が添付されていない場合にtrueを返すメソッド
+  def image_blank?
+    !image.attached? && persisted? # 更新時で画像が添付されていない場合
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,7 +28,7 @@ class Item < ApplicationRecord
 
   # 商品画像
   has_one_attached :image
-  validates :image, presence: true, if: :image_blank?
+  validates :image, presence: true
 
   # 売却済みかどうかを判定するメソッド
   # def sold_out?
@@ -37,8 +37,4 @@ class Item < ApplicationRecord
 
   private
 
-  # 画像が添付されていない場合にtrueを返すメソッド
-  def image_blank?
-    !image.attached? && persisted? # 更新時で画像が添付されていない場合
-  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,4 @@
 class Order < ApplicationRecord
-  #belongs_to :user
-  #belongs_to :item
+  # belongs_to :user
+  # belongs_to :item
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,143 +1,166 @@
+<%# cssは商品出品のものを併用しています。 app/assets/stylesheets/items/new.css %>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
   </header>
+
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true do |f| %>
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :image, id: "item-image" %> <!-- 修正: :hoge → :image -->
-      </div>
-    </div>
+    <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> <!-- 修正: :hoge → :name -->
-      
-      <div class="items-explain">
+      <% render 'shared/error_messages', model: f.object %>
+
+      <%# 商品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          商品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）", rows:"7", maxlength:"1000" %> <!-- 修正: :hoge → :description -->
-      </div>
-    </div>
 
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
-        <div class="weight-bold-text">
-          カテゴリー
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select :category_id, Category.all, :id, :name, {}, { class:"select-box", id:"item-category" } %> <!-- 修正: :hoge → :category_id, データ追加 -->
-        
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select :status, Item::STATUS_OPTIONS, :id, :name, {}, { class:"select-box", id:"item-sales-status" } %> <!-- 修正: :hoge → :status -->
-      </div>
-    </div>
+        <%# 現在の画像がある場合は表示 %>
+        <% if @item.image.attached? %>
+          <div class="current-image">
+            <%= image_tag @item.image, size: '100x100' %>
+            <p>現在の画像</p>
+          </div>
+        <% else %>
+          <%# 現在画像がない場合はデフォルト画像を表示 %>
+          <div class="current-image">
+            <%= image_tag 'item-sample.png', size: '100x100' %>
+            <p>デフォルト画像</p>
+          </div>
+        <% end %>
 
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id: "item-image", class: "file-input" %>
         </div>
-        <%= f.collection_select :shipping_fee_status, ShippingFeeStatus.all, :id, :name, {}, { class:"select-box", id:"item-shipping-fee-status" } %> <!-- 修正: :hoge → :shipping_fee_status -->
+      </div>
+      <%# /商品画像 %>
 
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
         <div class="weight-bold-text">
-          発送元の地域
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select :prefecture, Prefecture.all, :id, :name, {}, { class:"select-box", id:"item-prefecture" } %> <!-- 修正: :hoge → :prefecture -->
-        
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select :scheduled_delivery, DeliverySchedule.all, :id, :name, {}, { class:"select-box", id:"item-scheduled-delivery" } %> <!-- 修正: :hoge → :scheduled_delivery -->
-      </div>
-    </div>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> <!-- 修正: :hoge → :price -->
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
+      <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
+      <%# 商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :category_id, Category.all, :id, :name, {}, { class: "select-box", id: "item-category", required: true } %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :condition_id, Condition.all, :id, :name, {}, { class: "select-box", id: "item-condition", required: true } %>
+        </div>
+      </div>
+      <%# /商品の詳細 %>
 
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する", class:"sell-btn" %>
-      <%= link_to 'もどる', "#", class:"back-btn" %>
-    </div>
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, { prompt: "選択してください" }, { class: "select-box", id: "item-shipping-fee", required: true } %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, { class: "select-box", id: "item-prefecture", required: true } %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, { prompt: "選択してください" }, { class: "select-box", id: "item-shipping-day", required: true } %>
+        </div>
+      </div>
+      <%# /配送について %>
 
-  </div>
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.number_field :price, class:"price-input", id:"item-price", placeholder:"例）300", min: 300, max: 9999999, required: true %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
+    </div>
   <% end %>
 
   <footer class="items-sell-footer">
@@ -146,7 +169,7 @@
       <li><a href="#">フリマ利用規約</a></li>
       <li><a href="#">特定商取引に関する表記</a></li>
     </ul>
-    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <%= link_to image_tag('furima-logo-color.png', size: '185x50'), "/" %>
     <p class="inc">
       ©︎Furima,Inc.
     </p>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,6 @@
           <%= link_to item_path(item), class: 'list' do %> <%# ← 修正: <li>を直接囲む %>
             <div class='item-img-content'>
               <%# ① 商品画像 %>
-              <% if item.image.attached? %>
-                <%= image_tag item.image, class: "item-img" %>
-              <% else %>
-                <%= image_tag "item-sample.png", class: "item-img" %>
-              <% end %>    
               <div class='item-info'>
                 <%# ③ 商品名 %>
                 <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,11 +130,14 @@
     <ul class='item-lists'>
       <% if @items.present? %>
         <% @items.order(created_at: :desc).each do |item| %>        
-          <%= link_to item_path(item), class: 'list' do %> 
+          <%= link_to item_path(item), class: 'list' do %> <%# ← 修正: <li>を直接囲む %>
             <div class='item-img-content'>
               <%# ① 商品画像 %>
-              <%= image_tag item.image, class: "item-img" %>
-    
+              <% if item.image.attached? %>
+                <%= image_tag item.image, class: "item-img" %>
+              <% else %>
+                <%= image_tag "item-sample.png", class: "item-img" %>
+              <% end %>    
               <div class='item-info'>
                 <%# ③ 商品名 %>
                 <h3 class='item-name'>
@@ -179,8 +182,10 @@
 
 </div>
 
+<% if user_signed_in? %>
   <%= link_to(new_item_path, class: 'purchase-btn') do %>
     <span class='purchase-btn-text'>出品する</span>
     <%= image_tag 'icon_camera.png', size: '185x50', class: "purchase-btn-icon" %>
   <% end %>
+<% end %>
 <%= render "shared/footer" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -177,10 +177,8 @@
 
 </div>
 
-<% if user_signed_in? %>
   <%= link_to(new_item_path, class: 'purchase-btn') do %>
     <span class='purchase-btn-text'>出品する</span>
     <%= image_tag 'icon_camera.png', size: '185x50', class: "purchase-btn-icon" %>
   <% end %>
-<% end %>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <% if user_signed_in? %> 
       <% if current_user == @item.user %>  <!-- 商品詳細画面にアクセスしたユーザーが出品者である場合 -->
         <%# 商品編集・削除ボタン %>
-        <%= link_to "商品の編集", `#`, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", `#`, method: :delete, data: { confirm: "本当に削除しますか？" }, class: "item-destroy" %>
       <% else %>  <!-- 出品者でない場合 -->


### PR DESCRIPTION
What 
商品情報編集機能の実装

Why　
最終課題実装のため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://i.gyazo.com/aa98ef6f222afc119fd876e1d15ceb5c.mp4


必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://i.gyazo.com/7ba922be041b5dd2aa984a84a1f02149.mp4


入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://i.gyazo.com/763b47b57ab51453374d065bcd73bf89.mp4


何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://i.gyazo.com/e51c73154cf37b1deda2c10b90562644.mp4


ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://i.gyazo.com/7486055d36d79a23888da7c1989e0bf8.mp4


ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
購入機能未実装


ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://i.gyazo.com/fe36ab1f81769c295cb7f7f4a0aff3e6.mp4


商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://i.gyazo.com/87839fb9d8f4442a45b247ab0a461be6.mp4
